### PR TITLE
Add House

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ More info [here](http://www.frida.re/).
 - [frida-cycript](https://github.com/nowsecure/frida-cycript) - Fork of cycript with new runtime called [Mjølner](https://github.com/nowsecure/mjolner) powered by Frida.
 - [r2frida](https://github.com/nowsecure/r2frida) - static and dynamic analysis synergy
 - [ios-inject-custom](https://github.com/oleavr/ios-inject-custom) - use Frida for standalone injection of a custom payload for iOS.
-- [House](https://github.com/nccgroup/house) - A runtime mobile application analysis toolkit with a Web GUI, powered by Frida
 
 <a name="talks-and-papers" />
 
@@ -79,6 +78,7 @@ More info [here](http://www.frida.re/).
 <a name="frida-powered-by" />
 
 ## Powered by Frida
+* [House](https://github.com/nccgroup/house) - A runtime mobile application analysis toolkit with a Web GUI, powered by Frida
 * [Aurora](https://github.com/frida/aurora) - Web app built on top of Frida
 * [CloudSpy](https://github.com/frida/cloudspy) - Web app built on top of Frida
 * [CryptoShark](https://github.com/frida/cryptoshark) - Self-optimizing cross-platform code tracer based on dynamic recompilation

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ More info [here](http://www.frida.re/).
 - [frida-cycript](https://github.com/nowsecure/frida-cycript) - Fork of cycript with new runtime called [Mjølner](https://github.com/nowsecure/mjolner) powered by Frida.
 - [r2frida](https://github.com/nowsecure/r2frida) - static and dynamic analysis synergy
 - [ios-inject-custom](https://github.com/oleavr/ios-inject-custom) - use Frida for standalone injection of a custom payload for iOS.
+- [House](https://github.com/nccgroup/house) - A runtime mobile application analysis toolkit with a Web GUI, powered by Frida
 
 <a name="talks-and-papers" />
 


### PR DESCRIPTION
House: A runtime mobile application analysis toolkit with a Web GUI, powered by Frida, written in Python. It is designed for helping assess mobile applications by implementing dynamic function hooking and intercepting and intended to make Frida script writing as simple as possible.