### PR TITLE
Add XposedFridaBridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ More info [here](http://www.frida.re/).
 - [r2frida](https://github.com/nowsecure/r2frida) - static and dynamic analysis synergy
 - [ios-inject-custom](https://github.com/oleavr/ios-inject-custom) - use Frida for standalone injection of a custom payload for iOS.
 - [davuxcom/frida-scripts](https://github.com/davuxcom/frida-scripts) - Repository including scripts for COM, .NET and WinRT for Windows
+- [XposedFridaBridge](https://github.com/monkeylord/XposedFridaBridge) - A frida script implement XposedBridge & load xposed modules, without installing xposed framwork.
 
 <a name="talks-and-papers" />
 


### PR DESCRIPTION
XposedFridaBridge is a frida script that implement XposedBridge & load xposed modules, without installing xposed framwork.