### PR TITLE
Add rekit to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ More info [here](http://www.frida.re/).
 - [Arida](https://github.com/lateautumn4lin/arida) - A Frida-RPC tool based on FastAPI, Help users quickly realize interface exposure.
 - [easy-frida](https://github.com/tacesrever/easy-frida) - A tool for easily develop frida agent script/module when reversing, including some useful frida scripts.
 - [RoboDroid](https://github.com/cybersecsi/robodroid) - A tool for manage and deploy Android machines with pre-defined behaviors (made with Frida) for Cyber Range environments.
+- [rekit](https://github.com/b-erdem/rekit) - Reverse engineering toolkit for mobile APIs. Captures Android HTTP traffic via Frida hooks (OkHttp, Dio, URLConnection, WebView) above TLS without proxy setup, outputs HAR files, and includes tools for endpoint scanning, TLS fingerprint testing, and API client generation.
 
 <a name="talks-and-papers" />
 


### PR DESCRIPTION
## What is rekit?

[rekit](https://github.com/b-erdem/rekit) is a reverse engineering toolkit for mobile APIs with 6 focused tools for the RE pipeline.

**Frida-related features:**
- **apktap** — Captures Android HTTP traffic via Frida hooks (OkHttp3, Dio/BoringSSL, URLConnection, WebView) above TLS, without proxy setup. Outputs standard HAR 1.2 files.
- Hooks use `Java.perform` / `Java.use` for Java-layer interception and `Interceptor.attach` for native BoringSSL hooks.

**Other tools in the toolkit:**
- hargen — Generate typed Python API clients from HAR files
- apkmap — Scan decompiled APKs for API endpoints
- ja3probe — Test TLS fingerprint acceptance
- botwall — Detect bot protection systems
- schemadiff — Compare and unify API schemas

MIT licensed, Python 3.9+.